### PR TITLE
Ver2.1開発

### DIFF
--- a/OcrModules/OcrReader.py
+++ b/OcrModules/OcrReader.py
@@ -3,9 +3,9 @@ import pytesseract
 
 
 def read(image):
-    return pytesseract.image_to_string(image)
+    return pytesseract.image_to_string(image, config='--psm 6')
 
 
 if __name__ == '__main__':
-    FILENAME = './testimage2.jpg'
-    print(pytesseract.image_to_string(Image.open(FILENAME)))
+    FILENAME = './test_cutimage.png'
+    print(pytesseract.image_to_string(Image.open(FILENAME),config='--psm 6'))

--- a/PdfToImage/ImageConverter.py
+++ b/PdfToImage/ImageConverter.py
@@ -2,13 +2,12 @@ from pdf2image import convert_from_path
 from PIL import Image
 
 
-def to_jpeg(pdf_path):
+def to_image(pdf_path):
     return convert_from_path(pdf_path)
 
 
-def cutting_out(image_path, left, upper, right, lower):
-    images = convert_from_path(image_path)
-    return images[0].crop((int(left), int(upper), int(right), int(lower)))
+def cutting_out(image, left, upper, right, lower):
+    return image.crop((int(left), int(upper), int(right), int(lower)))
 
 
 if __name__ == '__main__':

--- a/TestData/MaterialReport/dupon/OcrMapping_TestReport.csv
+++ b/TestData/MaterialReport/dupon/OcrMapping_TestReport.csv
@@ -1,5 +1,5 @@
-item,left,upper,right,lower
-data1,233,200,365,256
-data2,1220,266,1476,299
-data3,1090,518,1247,591
-data4,1039,2120,1204,2165
+item,left,upper,right,lower,pageNo
+data1,233,200,365,256,0
+data2,1220,266,1476,299,0
+data3,1090,518,1247,591,0
+data4,1039,2120,1204,2165,0

--- a/main.py
+++ b/main.py
@@ -47,7 +47,8 @@ def run(filename):
 
     next(config)
     for row in config:
-        cut_image = Converter.cutting_out(files[0], row[1], row[2], row[3], row[4])
+        image_page = Converter.to_image(files[0])[int(row[5])]
+        cut_image = Converter.cutting_out(image_page, row[1], row[2], row[3], row[4])
         # cut_image.show()
         result_list.append(Reader.read(cut_image))
         header.append(row[0])


### PR DESCRIPTION
## 概要
PDFファイルが複数ページであっても読み取りができるように仕様を変更。

## 変更内容
### ImageConverter.py
- cuttting_outメソッドの引数：imageを直接イメージデータを受け取る
- to_jpegメソッドの名称をto_imageメソッドに変更
### Main.py
- Mappingファイルの最終行にpageNo指定列を追加
### OcrReader.py
- readメソッド内のtesseract呼び出し時にページセグメンテーションの指定を追加：'--psm 6'